### PR TITLE
predicate_validator() can run on each item in a container. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridworks-protocol"
-version = "0.2.2"
+version = "0.2.3"
 description = "Gridworks Protocol"
 authors = ["Jessica Millar <jmillar@gridworks-consulting.com>"]
 license = "MIT"

--- a/src/gwproto/property_format.py
+++ b/src/gwproto/property_format.py
@@ -8,8 +8,42 @@ import pydantic
 
 
 def predicate_validator(
-    field_name: str, predicate: Callable[[Any], bool], error_format: str = ""
+    field_name: str, predicate: Callable[[Any], bool], error_format: str = "", **kwargs
 ) -> classmethod:  # type: ignore
+    """
+    Produce a pydantic validator from a function returning a bool.
+
+    Example:
+
+        from typing import Any
+        from pydantic import BaseModel, ValidationError
+        from gwproto.property_format import predicate_validator
+
+        def is_truthy(v: Any) -> bool:
+            return bool(v)
+
+        class Foo(BaseModel):
+            an_int: int
+
+            _validate_an_int = predicate_validator("an_int", is_truthy)
+
+        print(Foo(an_int=1))
+
+        try:
+            print(Foo(an_int=0))
+        except ValidationError as e:
+            print(e)
+
+    Args:
+        field_name: the name of the field to validate.
+        predicate: the validation function. A truthy return value indicates success.
+        error_format: Optional format string for use in exception raised by validation failure. Takes one parameter, 'v'.
+        **kwargs: Passed to pydantic.validator()
+
+    Returns:
+        The passed in object v.
+    """
+
     def _validator(v: Any) -> Any:
         if not predicate(v):
             if error_format:
@@ -19,7 +53,7 @@ def predicate_validator(
             raise ValueError(err_str)
         return v
 
-    return pydantic.validator(field_name, allow_reuse=True)(_validator)
+    return pydantic.validator(field_name, allow_reuse=True, **kwargs)(_validator)
 
 
 def is_bit(candidate: int) -> bool:


### PR DESCRIPTION
predicate_validator() accepts kwargs passed to pydantic.validator() so that predicate_validator() can, for example, by used to validate each item in a list