### PR TITLE
Remove need for enum validators

### DIFF
--- a/src/gwproto/enums/actor_class.py
+++ b/src/gwproto/enums/actor_class.py
@@ -83,13 +83,6 @@ class ActorClass(StrEnum):
         return cls.NoActor
 
     @classmethod
-    def values(cls) -> List[str]:
-        """
-        Returns enum choices
-        """
-        return [elt.value for elt in cls]  # noqa
-
-    @classmethod
     def version(cls, value: str) -> str:
         """
         Returns the version of an enum value.

--- a/src/gwproto/enums/better_str_enum.py
+++ b/src/gwproto/enums/better_str_enum.py
@@ -1,5 +1,8 @@
+from enum import auto
 from enum import StrEnum
 from typing import Any
+from typing import Optional
+from typing import Self
 
 
 class BetterStrEnum(StrEnum):
@@ -11,3 +14,19 @@ class BetterStrEnum(StrEnum):
         last_values: list[Any],  # noqa: ARG004
     ) -> str:
         return name
+
+    @classmethod
+    def values(cls) -> list[str]:
+        return [str(elt) for elt in cls]
+
+    @classmethod
+    def default(cls) -> Optional[Self]:
+        return None
+
+
+    @classmethod
+    def _missing_(cls, value: str) -> Self:
+        default = cls.default()
+        if default is None:
+            raise ValueError(f"'{value}' is not valid {cls.__name__}")
+        return default

--- a/src/gwproto/enums/better_str_enum.py
+++ b/src/gwproto/enums/better_str_enum.py
@@ -1,8 +1,5 @@
-from enum import auto
 from enum import StrEnum
-from typing import Any
-from typing import Optional
-from typing import Self
+from typing import Any, Optional, Self
 
 
 class BetterStrEnum(StrEnum):
@@ -22,7 +19,6 @@ class BetterStrEnum(StrEnum):
     @classmethod
     def default(cls) -> Optional[Self]:
         return None
-
 
     @classmethod
     def _missing_(cls, value: str) -> Self:

--- a/src/gwproto/enums/local_comm_interface.py
+++ b/src/gwproto/enums/local_comm_interface.py
@@ -45,13 +45,6 @@ class LocalCommInterface(StrEnum):
         return cls.UNKNOWN
 
     @classmethod
-    def values(cls) -> List[str]:
-        """
-        Returns enum choices
-        """
-        return [elt.value for elt in cls]  # noqa: ALL
-
-    @classmethod
     def version(cls, value: str) -> str:
         """
         Returns the version of an enum value.

--- a/src/gwproto/enums/make_model.py
+++ b/src/gwproto/enums/make_model.py
@@ -90,13 +90,6 @@ class MakeModel(StrEnum):
         return cls.UNKNOWNMAKE__UNKNOWNMODEL
 
     @classmethod
-    def values(cls) -> List[str]:
-        """
-        Returns enum choices
-        """
-        return [elt.value for elt in cls]  # noqa: ALL
-
-    @classmethod
     def version(cls, value: str) -> str:
         """
         Returns the version of an enum value.

--- a/src/gwproto/enums/role.py
+++ b/src/gwproto/enums/role.py
@@ -78,13 +78,6 @@ class Role(StrEnum):
         return cls.Unknown
 
     @classmethod
-    def values(cls) -> List[str]:
-        """
-        Returns enum choices
-        """
-        return [elt.value for elt in cls]  # noqa: ALL
-
-    @classmethod
     def version(cls, value: str) -> str:
         """
         Returns the version of an enum value.

--- a/src/gwproto/enums/telemetry_name.py
+++ b/src/gwproto/enums/telemetry_name.py
@@ -67,13 +67,6 @@ class TelemetryName(StrEnum):
         return cls.Unknown
 
     @classmethod
-    def values(cls) -> List[str]:
-        """
-        Returns enum choices
-        """
-        return [elt.value for elt in cls]  # noqa: ALL
-
-    @classmethod
     def version(cls, value: str) -> str:
         """
         Returns the version of an enum value.

--- a/src/gwproto/enums/unit.py
+++ b/src/gwproto/enums/unit.py
@@ -49,13 +49,6 @@ class Unit(StrEnum):
         return cls.Unknown
 
     @classmethod
-    def values(cls) -> List[str]:
-        """
-        Returns enum choices
-        """
-        return [elt.value for elt in cls]  # noqa: ALL
-
-    @classmethod
     def version(cls, value: str) -> str:
         """
         Returns the version of an enum value.


### PR DESCRIPTION
By combining pythons [Enum._missing_()](https://docs.python.org/3/library/enum.html#enum.Enum._missing_) functionality with the our existing `default()` functions we remove need for an enum validator that converts a unknown value to the default. The values() function can also be moved into the base class