### PR TITLE
vscode: adds workspace with ruff visual feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ hacking
 .idea
 scratch*
 cook.sh
-.vscode
 
 # Code generation airtable
 CodeGenerationTools/GridworksCore/SassyMQ/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["ms.python", "charliermarsh.ruff"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+	"ruff.enable": true,
+	"ruff.fixAll": true,
+	"python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
… adding settings.json and extensions.json which include ruff. Pylance type testing not enabled since that will turn up many errors; see as/mypy branch for type-checked code