### PR TITLE
Loosen compatibility requirements (#455)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python: "3.12", os: "ubuntu-latest", session: "pre-commit" }
+          - { python: "3.13", os: "ubuntu-latest", session: "pre-commit" }
+          - { python: "3.13", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.12", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.11", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.11", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.12", os: "ubuntu-latest", session: "tests", coverage: true}
-          - { python: "3.12", os: "windows-latest", session: "tests" }
-          - { python: "3.12", os: "macos-latest", session: "tests" }
-          - { python: "3.12", os: "ubuntu-latest", session: "xdoctest" }
-          - { python: "3.12", os: "ubuntu-latest", session: "docs-build" }
+          - { python: "3.13", os: "ubuntu-latest", session: "tests", coverage: true}
+          - { python: "3.12", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.13", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.13", os: "windows-latest", session: "tests" }
+          - { python: "3.13", os: "macos-latest", session: "tests" }
+          - { python: "3.13", os: "ubuntu-latest", session: "xdoctest" }
+          - { python: "3.13", os: "ubuntu-latest", session: "docs-build" }
     env:
       NOXSESSION: ${{ matrix.session }}
       FORCE_COLOR: "1"
@@ -149,7 +151,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Upgrade pip
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ except ImportError:
 
 
 package = "gwproto"
-python_versions = ["3.12", "3.11"]
+python_versions = ["3.13", "3.12", "3.11"]
 
 nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridworks-protocol"
-version = "1.2.4"
+version = "1.2.5"
 description = "Gridworks Protocol"
 authors = ["Jessica Millar <jmillar@gridworks-consulting.com>"]
 license = "MIT"

--- a/src/gwproto/data_classes/sh_node.py
+++ b/src/gwproto/data_classes/sh_node.py
@@ -53,6 +53,10 @@ class ShNode(SpaceheatNodeGt):
 
     @property
     def actor_class(self) -> ActorClassEnum:
+        return ActorClassEnum(self.ActorClass)
+
+    @property
+    def actor_class_str(self) -> str:
         return self.ActorClass
 
     @property

--- a/src/gwproto/message.py
+++ b/src/gwproto/message.py
@@ -35,7 +35,7 @@ class Header(BaseModel):
     MessageId: str = ""
     AckRequired: bool = False
     TypeName: Literal["gridworks.header"] = "gridworks.header"
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 # MyPy needs this because the class variable of Message is 'Header'.

--- a/src/gwproto/messages/event.py
+++ b/src/gwproto/messages/event.py
@@ -41,7 +41,7 @@ class StartupEvent(EventBase):
 class ShutdownEvent(EventBase):
     Reason: str
     TypeName: Literal["gridworks.event.shutdown"] = "gridworks.event.shutdown"
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 class Problems(Enum):
@@ -54,7 +54,7 @@ class ProblemEvent(EventBase):
     Summary: str
     Details: str = ""
     TypeName: Literal["gridworks.event.problem"] = "gridworks.event.problem"
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
     @field_validator("ProblemType", mode="before")
     @classmethod
@@ -73,48 +73,48 @@ class MQTTConnectEvent(MQTTCommEvent):
     TypeName: Literal["gridworks.event.comm.mqtt.connect"] = (
         "gridworks.event.comm.mqtt.connect"
     )
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 class MQTTConnectFailedEvent(MQTTCommEvent):
     TypeName: Literal["gridworks.event.comm.mqtt.connect.failed"] = (
         "gridworks.event.comm.mqtt.connect.failed"
     )
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 class MQTTDisconnectEvent(MQTTCommEvent):
     TypeName: Literal["gridworks.event.comm.mqtt.disconnect"] = (
         "gridworks.event.comm.mqtt.disconnect"
     )
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 class MQTTFullySubscribedEvent(CommEvent):
     TypeName: Literal["gridworks.event.comm.mqtt.fully.subscribed"] = (
         "gridworks.event.comm.mqtt.fully.subscribed"
     )
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 class ResponseTimeoutEvent(CommEvent):
     TypeName: Literal["gridworks.event.comm.response.timeout"] = (
         "gridworks.event.comm.response.timeout"
     )
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 class PeerActiveEvent(CommEvent):
     TypeName: Literal["gridworks.event.comm.peer.active"] = (
         "gridworks.event.comm.peer.active"
     )
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
 
 class ReportEvent(EventBase):
     Report: Report
     TypeName: Literal["report.event"] = "report.event"
-    Version: Literal["000", "002"] = "002"
+    Version: str = "002"
 
     @model_validator(mode="after")
     def infer_base_fields(self) -> Self:

--- a/src/gwproto/named_types/ads111x_based_cac_gt.py
+++ b/src/gwproto/named_types/ads111x_based_cac_gt.py
@@ -23,7 +23,7 @@ class Ads111xBasedCacGt(ComponentAttributeClassGt):
     TotalTerminalBlocks: PositiveInt
     TelemetryNameList: list[TelemetryName]
     TypeName: Literal["ads111x.based.cac.gt"] = "ads111x.based.cac.gt"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)
 

--- a/src/gwproto/named_types/ads111x_based_component_gt.py
+++ b/src/gwproto/named_types/ads111x_based_component_gt.py
@@ -18,7 +18,7 @@ class Ads111xBasedComponentGt(ComponentGt):
     OpenVoltageByAds: list[float]
     ConfigList: Sequence[AdsChannelConfig]
     TypeName: Literal["ads111x.based.component.gt"] = "ads111x.based.component.gt"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/src/gwproto/named_types/ads_channel_config.py
+++ b/src/gwproto/named_types/ads_channel_config.py
@@ -18,6 +18,6 @@ class AdsChannelConfig(ChannelConfig):
     DataProcessingMethod: Optional[ThermistorDataMethod] = None
     DataProcessingDescription: Optional[str] = None
     TypeName: Literal["ads.channel.config"] = "ads.channel.config"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)

--- a/src/gwproto/named_types/alert.py
+++ b/src/gwproto/named_types/alert.py
@@ -18,4 +18,4 @@ class Alert(BaseModel):
     Summary: str
     OpsGenieAlias: Optional[str] = None
     TypeName: Literal["alert"] = "alert"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/analog_dispatch.py
+++ b/src/gwproto/named_types/analog_dispatch.py
@@ -23,7 +23,7 @@ class AnalogDispatch(BaseModel):
     TriggerId: UUID4Str
     UnixTimeMs: UTCMilliseconds
     TypeName: Literal["analog.dispatch"] = "analog.dispatch"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/channel_readings.py
+++ b/src/gwproto/named_types/channel_readings.py
@@ -23,7 +23,7 @@ class ChannelReadings(BaseModel):
     ValueList: list[StrictInt]
     ScadaReadTimeUnixMsList: list[UTCMilliseconds]
     TypeName: Literal["channel.readings"] = "channel.readings"
-    Version: Literal["002"] = "002"
+    Version: str = "002"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/data_channel_gt.py
+++ b/src/gwproto/named_types/data_channel_gt.py
@@ -25,7 +25,7 @@ class DataChannelGt(BaseModel):
     StartS: Optional[UTCSeconds] = None
     Id: UUID4Str
     TypeName: Literal["data.channel.gt"] = "data.channel.gt"
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/dfr_component_gt.py
+++ b/src/gwproto/named_types/dfr_component_gt.py
@@ -13,4 +13,4 @@ class DfrComponentGt(ComponentGt):
     ConfigList: Sequence[DfrConfig]
     I2cAddressList: list[PositiveInt]
     TypeName: Literal["dfr.component.gt"] = "dfr.component.gt"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/dfr_config.py
+++ b/src/gwproto/named_types/dfr_config.py
@@ -11,4 +11,4 @@ class DfrConfig(ChannelConfig):
     OutputIdx: PositiveInt
     InitialVoltsTimes100: StrictInt
     TypeName: Literal["dfr.config"] = "dfr.config"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/egauge_register_config.py
+++ b/src/gwproto/named_types/egauge_register_config.py
@@ -46,4 +46,4 @@ class EgaugeRegisterConfig(BaseModel):
         description="The EGauge unit - typically A, Hz, or W.",
     )
     TypeName: Literal["egauge.register.config"] = "egauge.register.config"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/electric_meter_cac_gt.py
+++ b/src/gwproto/named_types/electric_meter_cac_gt.py
@@ -10,4 +10,4 @@ class ElectricMeterCacGt(ComponentAttributeClassGt):
     TelemetryNameList: list[TelemetryName]
     DefaultBaud: Optional[int] = None
     TypeName: Literal["electric.meter.cac.gt"] = "electric.meter.cac.gt"
-    Version: Literal["001"] = "001"
+    Version: str = "001"

--- a/src/gwproto/named_types/electric_meter_channel_config.py
+++ b/src/gwproto/named_types/electric_meter_channel_config.py
@@ -11,4 +11,4 @@ from gwproto.named_types.egauge_register_config import (
 class ElectricMeterChannelConfig(ChannelConfig):
     EgaugeRegisterConfig: Optional[EgaugeConfig] = None
     TypeName: Literal["electric.meter.channel.config"] = "electric.meter.channel.config"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/electric_meter_component_gt.py
+++ b/src/gwproto/named_types/electric_meter_component_gt.py
@@ -14,7 +14,7 @@ class ElectricMeterComponentGt(ComponentGt):
     ModbusPort: Optional[PositiveInt] = None
     ConfigList: Sequence[ElectricMeterChannelConfig]
     TypeName: Literal["electric.meter.component.gt"] = "electric.meter.component.gt"
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
     @field_validator("ConfigList")
     @classmethod

--- a/src/gwproto/named_types/fsm_atomic_report.py
+++ b/src/gwproto/named_types/fsm_atomic_report.py
@@ -27,7 +27,7 @@ class FsmAtomicReport(BaseModel):
     UnixTimeMs: UTCMilliseconds
     TriggerId: UUID4Str
     TypeName: Literal["fsm.atomic.report"] = "fsm.atomic.report"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(extra="allow")
 

--- a/src/gwproto/named_types/fsm_full_report.py
+++ b/src/gwproto/named_types/fsm_full_report.py
@@ -16,6 +16,6 @@ class FsmFullReport(BaseModel):
     TriggerId: UUID4Str
     AtomicList: list[FsmAtomicReport]
     TypeName: Literal["fsm.full.report"] = "fsm.full.report"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)

--- a/src/gwproto/named_types/heartbeat_b.py
+++ b/src/gwproto/named_types/heartbeat_b.py
@@ -32,7 +32,7 @@ class HeartbeatB(BaseModel):
         ),
     )
     TypeName: Literal["heartbeat.b"] = "heartbeat.b"
-    Version: Literal["001"] = "001"
+    Version: str = "001"
 
     def __hash__(self) -> int:
         return hash((type(self), *self.__dict__.values()))

--- a/src/gwproto/named_types/i2c_multichannel_dt_relay_component_gt.py
+++ b/src/gwproto/named_types/i2c_multichannel_dt_relay_component_gt.py
@@ -15,7 +15,7 @@ class I2cMultichannelDtRelayComponentGt(ComponentGt):
     TypeName: Literal["i2c.multichannel.dt.relay.component.gt"] = (
         "i2c.multichannel.dt.relay.component.gt"
     )
-    Version: Literal["002"] = "002"
+    Version: str = "002"
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)
 

--- a/src/gwproto/named_types/keyparam_change_log.py
+++ b/src/gwproto/named_types/keyparam_change_log.py
@@ -31,7 +31,7 @@ class KeyparamChangeLog(BaseModel):
     Description: str
     Kind: KindOfParam
     TypeName: Literal["keyparam.change.log"] = "keyparam.change.log"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(extra="allow", use_enum_values=True)
 

--- a/src/gwproto/named_types/machine_states.py
+++ b/src/gwproto/named_types/machine_states.py
@@ -20,7 +20,7 @@ class MachineStates(BaseModel):
     StateList: list[str]
     UnixMsList: list[UTCMilliseconds]
     TypeName: Literal["machine.states"] = "machine.states"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/pico_flow_module_component_gt.py
+++ b/src/gwproto/named_types/pico_flow_module_component_gt.py
@@ -28,7 +28,7 @@ class PicoFlowModuleComponentGt(ComponentGt):
     ExpAlpha: Optional[float] = None
     CutoffFrequency: Optional[float] = None
     TypeName: Literal["pico.flow.module.component.gt"] = "pico.flow.module.component.gt"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     @field_validator("HwUid")
     @classmethod

--- a/src/gwproto/named_types/pico_tank_module_component_gt.py
+++ b/src/gwproto/named_types/pico_tank_module_component_gt.py
@@ -22,7 +22,7 @@ class PicoTankModuleComponentGt(ComponentGt):
     SerialNumber: str = "NA"
     AsyncCaptureDeltaMicroVolts: int
     TypeName: Literal["pico.tank.module.component.gt"] = "pico.tank.module.component.gt"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(extra="allow")
 

--- a/src/gwproto/named_types/power_watts.py
+++ b/src/gwproto/named_types/power_watts.py
@@ -18,4 +18,4 @@ class PowerWatts(BaseModel):
 
     Watts: int
     TypeName: Literal["power.watts"] = "power.watts"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/relay_actor_config.py
+++ b/src/gwproto/named_types/relay_actor_config.py
@@ -35,7 +35,7 @@ class RelayActorConfig(ChannelConfig):
     DeEnergizedState: str
     EnergizedState: str
     TypeName: Literal["relay.actor.config"] = "relay.actor.config"
-    Version: Literal["002"] = "002"
+    Version: str = "002"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/report.py
+++ b/src/gwproto/named_types/report.py
@@ -29,7 +29,7 @@ class Report(BaseModel):
     MessageCreatedMs: UTCMilliseconds
     Id: UUID4Str
     TypeName: Literal["report"] = "report"
-    Version: Literal["002"] = "002"
+    Version: str = "002"
 
     @field_validator("ChannelReadingList")
     @classmethod

--- a/src/gwproto/named_types/send_snap.py
+++ b/src/gwproto/named_types/send_snap.py
@@ -12,4 +12,4 @@ from gwproto.property_format import (
 class SendSnap(BaseModel):
     FromGNodeAlias: LeftRightDotStr
     TypeName: Literal["send.snap"] = "send.snap"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/single_reading.py
+++ b/src/gwproto/named_types/single_reading.py
@@ -15,6 +15,6 @@ class SingleReading(BaseModel):
     Value: StrictInt
     ScadaReadTimeUnixMs: UTCMilliseconds
     TypeName: Literal["single.reading"] = "single.reading"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(use_enum_values=True)

--- a/src/gwproto/named_types/spaceheat_node_gt.py
+++ b/src/gwproto/named_types/spaceheat_node_gt.py
@@ -5,7 +5,6 @@ from typing import Literal, Optional
 from pydantic import BaseModel, ConfigDict, StrictInt, model_validator
 from typing_extensions import Self
 
-from gwproto.enums import ActorClass
 from gwproto.property_format import HandleName, SpaceheatName, UUID4Str
 
 
@@ -13,14 +12,14 @@ class SpaceheatNodeGt(BaseModel):
     Name: SpaceheatName
     ActorHierarchyName: Optional[HandleName] = None
     Handle: Optional[HandleName] = None
-    ActorClass: ActorClass
+    ActorClass: str
     DisplayName: Optional[str] = None
     ComponentId: Optional[str] = None
     NameplatePowerW: Optional[StrictInt] = None
     InPowerMetering: Optional[bool] = None
     ShNodeId: UUID4Str
     TypeName: Literal["spaceheat.node.gt"] = "spaceheat.node.gt"
-    Version: Literal["200"] = "200"
+    Version: str = "200"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/synced_readings.py
+++ b/src/gwproto/named_types/synced_readings.py
@@ -16,7 +16,7 @@ class SyncedReadings(BaseModel):
     ValueList: list[StrictInt]
     ScadaReadTimeUnixMs: UTCMilliseconds
     TypeName: Literal["synced.readings"] = "synced.readings"
-    Version: Literal["000"] = "000"
+    Version: str = "000"
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/src/gwproto/named_types/synth_channel_gt.py
+++ b/src/gwproto/named_types/synth_channel_gt.py
@@ -29,4 +29,4 @@ class SynthChannelGt(BaseModel):
     DisplayName: str
     SyncReportMinutes: PositiveInt
     TypeName: Literal["synth.channel.gt"] = "synth.channel.gt"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/tank_module_params.py
+++ b/src/gwproto/named_types/tank_module_params.py
@@ -23,7 +23,7 @@ class TankModuleParams(BaseModel):
     AsyncCaptureDeltaMicroVolts: PositiveInt
     CaptureOffsetS: Optional[float] = None
     TypeName: Literal["tank.module.params"] = "tank.module.params"
-    Version: Literal["100"] = "100"
+    Version: str = "100"
 
     @field_validator("PicoAB")
     @classmethod

--- a/src/gwproto/named_types/ticklist_hall.py
+++ b/src/gwproto/named_types/ticklist_hall.py
@@ -12,7 +12,7 @@ class TicklistHall(BaseModel):
     RelativeMicrosecondList: list[StrictInt]
     PicoBeforePostTimestampNanoSecond: StrictInt
     TypeName: Literal["ticklist.hall"] = "ticklist.hall"
-    Version: Literal["101"] = "101"
+    Version: str = "101"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/ticklist_hall_report.py
+++ b/src/gwproto/named_types/ticklist_hall_report.py
@@ -18,4 +18,4 @@ class TicklistHallReport(BaseModel):
     ScadaReceivedUnixMs: UTCMilliseconds
     Ticklist: TicklistHall
     TypeName: Literal["ticklist.hall.report"] = "ticklist.hall.report"
-    Version: Literal["000"] = "000"
+    Version: str = "000"

--- a/src/gwproto/named_types/ticklist_reed.py
+++ b/src/gwproto/named_types/ticklist_reed.py
@@ -12,7 +12,7 @@ class TicklistReed(BaseModel):
     RelativeMillisecondList: list[StrictInt]
     PicoBeforePostTimestampNanoSecond: StrictInt
     TypeName: Literal["ticklist.reed"] = "ticklist.reed"
-    Version: Literal["101"] = "101"
+    Version: str = "101"
 
     @model_validator(mode="after")
     def check_axiom_1(self) -> Self:

--- a/src/gwproto/named_types/ticklist_reed_report.py
+++ b/src/gwproto/named_types/ticklist_reed_report.py
@@ -18,4 +18,4 @@ class TicklistReedReport(BaseModel):
     ScadaReceivedUnixMs: UTCMilliseconds
     Ticklist: TicklistReed
     TypeName: Literal["ticklist.reed.report"] = "ticklist.reed.report"
-    Version: Literal["000"] = "000"
+    Version: str = "000"


### PR DESCRIPTION
Loosens some compatibility requirements so that gridworks-protocol can be used in non-spaceheat-scada contexts:
- Version fields are now strings, not literals, so that changing them does not prevent decoding.
- ActorClass is now a string, not an enum, so new actor classes do not have to appear in this package.
- Added HardwareLayout.add_node() so applications with very simple layouts can add nodes without needing a full hardware layout.

And incidentally add 3.13 support.