### PR TITLE
Remove alias generator from WebServerGt, since it prevents setting changes being read from dotenv file

### DIFF
--- a/src/gwproto/named_types/web_server_gt.py
+++ b/src/gwproto/named_types/web_server_gt.py
@@ -1,8 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
-
-from gwproto.utils import snake_to_camel
+from pydantic import BaseModel
 
 DEFAULT_WEB_SERVER_NAME = "default"
 
@@ -13,6 +11,3 @@ class WebServerGt(BaseModel):
     Port: int = 8080
     Enabled: bool = True
     Kwargs: dict[str, Any] = {}
-    model_config = ConfigDict(
-        extra="allow", alias_generator=snake_to_camel, populate_by_name=True
-    )


### PR DESCRIPTION
Remove alias generator from WebServerGt, since it prevents setting changes being read from dotenv file. See here: https://github.com/pydantic/pydantic-settings/issues/501.