### PR TITLE
Remove alias generator from WebServerGt, since it prevents setting changes being read from dotenv file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridworks-protocol"
-version = "1.2.5"
+version = "1.2.6"
 description = "Gridworks Protocol"
 authors = ["Jessica Millar <jmillar@gridworks-consulting.com>"]
 license = "MIT"


### PR DESCRIPTION
Remove alias generator from WebServerGt, since it prevents setting changes being read from dotenv file (see here: https://github.com/pydantic/pydantic-settings/issues/501)